### PR TITLE
fix: Wrap try() with coalesce() to overcome non-null defaults

### DIFF
--- a/grafana_alert.tf
+++ b/grafana_alert.tf
@@ -27,9 +27,9 @@ resource "grafana_rule_group" "this" {
       annotations = {for k, v in rule.value.annotations : k => replace(v, "$value", "$values.QUERY_RESULT.Value")}
       labels      = merge(rule.value.labels, try(var.overrides[rule.value.alert].labels, {}))
 
-      exec_err_state = try(var.overrides[rule.value.alert].exec_err_state, "Error")
+      exec_err_state = coalesce(try(var.overrides[rule.value.alert].exec_err_state, null), "Error")
       is_paused      = try(var.overrides[rule.value.alert].is_paused, null)
-      no_data_state  = try(var.overrides[rule.value.alert].no_data_state, "OK")
+      no_data_state  = coalesce(try(var.overrides[rule.value.alert].no_data_state, null), "OK")
 
       data {
         ref_id = "QUERY"
@@ -101,7 +101,7 @@ resource "grafana_rule_group" "this" {
           "conditions" = [
             {
               "evaluator" = {
-                "params" = [try(var.overrides[rule.value.alert].alert_threshold, 0)]
+                "params" = [coalesce(try(var.overrides[rule.value.alert].alert_threshold, null), 0)]
                 "type"   = "gt"
               }
               "operator" = {


### PR DESCRIPTION
It seems that only using the `try()` function results in a wrong behavior.

As soon as there is an override for an alert defined, Terraform sets all the optional attributes within the override structure to `null`. When the try function gets `null` instead of "undefined", it doesn't use the fallback value.